### PR TITLE
Add analytics utilities and pytest tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ streamlit==1.37.1
 pandas==2.2.2
 openpyxl==3.1.5
 numpy==1.26.4
+pytest==8.3.2

--- a/src/analytics.py
+++ b/src/analytics.py
@@ -3,6 +3,15 @@ import numpy as np
 import pandas as pd
 
 
+def normalize_weights(weights: dict[str, float]) -> dict[str, float]:
+    """Normalize weight values so they sum to 1.0.
+
+    If the total weight is zero, the original mapping is returned unchanged.
+    """
+    total = sum(weights.values())
+    return {k: v / total for k, v in weights.items()} if total else weights
+
+
 def compute_overall_score(df: pd.DataFrame, weights: dict[str, float]) -> pd.DataFrame:
     """Compute weighted overall score for each row if applicable."""
     def overall(row):

--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -16,12 +16,18 @@ def load_excel(file) -> pd.DataFrame:
     return pd.read_excel(file)
 
 
-def normalize_dataframe(df_raw: pd.DataFrame, mappings: dict[str, str]) -> pd.DataFrame:
-    """Return DataFrame with columns renamed to canonical keys and numeric fields coerced."""
+def map_columns(df_raw: pd.DataFrame, mappings: dict[str, str]) -> pd.DataFrame:
+    """Return DataFrame with columns renamed to canonical keys."""
     df = pd.DataFrame()
     for key, col in mappings.items():
         if col != "(ללא)" and col in df_raw.columns:
             df[key] = df_raw[col]
+    return df
+
+
+def normalize_dataframe(df_raw: pd.DataFrame, mappings: dict[str, str]) -> pd.DataFrame:
+    """Return DataFrame with columns renamed to canonical keys and numeric fields coerced."""
+    df = map_columns(df_raw, mappings)
     for nk in numeric_keys:
         if nk in df.columns:
             df[nk] = pd.to_numeric(df[nk], errors="coerce")

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -3,7 +3,7 @@ import streamlit as st
 
 from src.schema import load_schema, canonical_map
 from src.data_loader import load_excel, normalize_dataframe
-from src.analytics import compute_overall_score, compute_trends, apply_flags
+from src.analytics import compute_overall_score, compute_trends, apply_flags, normalize_weights
 from src.db import init_db, insert_dataframe, load_records
 
 st.set_page_config(page_title="Student Analytics MVP", layout="wide")
@@ -56,7 +56,7 @@ w_sum = sum(weights.values())
 if w_sum == 0:
     st.sidebar.warning("שימו לב: סכום המשקולות 0 — לא יחושב ציון כללי.")
 else:
-    weights = {k: v / w_sum for k, v in weights.items()}
+    weights = normalize_weights(weights)
 
 # Thresholds
 st.sidebar.subheader("קריטריונים (סינון)")

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,35 @@
+import pandas as pd
+import pytest
+
+from src.analytics import normalize_weights, compute_trends, apply_flags
+
+
+def test_normalize_weights():
+    weights = {"quiz_avg": 2.0, "quarter_exam": 6.0}
+    normalized = normalize_weights(weights)
+    assert pytest.approx(1.0) == sum(normalized.values())
+    assert normalized["quiz_avg"] == pytest.approx(0.25)
+    assert normalized["quarter_exam"] == pytest.approx(0.75)
+
+
+def test_apply_flags_percentile():
+    df = pd.DataFrame(
+        {"student_name": ["A", "B"], "national_percentile": [5, 20]}
+    )
+    result = apply_flags(df, low_percentile_thr=10, drop_thr=5, trend_fields=[])
+    assert result.loc[result["student_name"] == "A", "flagged"].iloc[0]
+    assert not result.loc[result["student_name"] == "B", "flagged"].iloc[0]
+
+
+def test_compute_trends():
+    df = pd.DataFrame(
+        [
+            {"student_name": "A", "semester": "א", "quiz_avg": 80},
+            {"student_name": "A", "semester": "ב", "quiz_avg": 90},
+        ]
+    )
+    out, trend_fields = compute_trends(df, ["quiz_avg"])
+    assert "quiz_avg" in trend_fields
+    assert "delta_quiz_avg" in out.columns
+    delta_val = out.loc[out["student_name"] == "A", "delta_quiz_avg"].iloc[0]
+    assert delta_val == 10


### PR DESCRIPTION
## Summary
- factor column mapping into `map_columns`
- expose `normalize_weights` and use it in the Streamlit app
- cover weight normalization, flag thresholds, and trend deltas with pytest

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0795d1158832998e2d17ac304a0f8