### PR TITLE
Revamp comments, login UI and add analytics tests

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -3,7 +3,12 @@ import streamlit as st
 
 from src.schema import load_schema, canonical_map
 from src.data_loader import load_excel, normalize_dataframe
-from src.analytics import compute_overall_score, compute_trends, apply_flags, normalize_weights
+from src.analytics import (
+    compute_overall_score,
+    compute_trends,
+    apply_flags,
+    normalize_weights,
+)
 from src.db import init_db, insert_dataframe, load_records
 
 st.set_page_config(page_title="Student Analytics MVP", layout="wide")
@@ -29,15 +34,25 @@ USERS = {
 
 
 def login() -> None:
-    st.sidebar.subheader("כניסה")
-    username = st.sidebar.text_input("שם משתמש")
-    password = st.sidebar.text_input("סיסמה", type="password")
-    if st.sidebar.button("התחבר"):
+    """Render a simple login form in the main area."""
+
+    st.header("🔐 כניסה")
+    col1, col2, col3 = st.columns([1, 2, 1])
+    with col2:
+        with st.form("login_form"):
+            username = st.text_input("שם משתמש", placeholder="Username")
+            password = st.text_input("סיסמה", type="password", placeholder="Password")
+            submitted = st.form_submit_button("התחבר", use_container_width=True)
+        st.caption(
+            "Roles available: 👩‍🏫 מורה, 👨‍💼 רכז, 🎓 תלמיד. "
+            "הפרטים רגישים לאותיות גדולות וקטנות."
+        )
+    if submitted:
         user = USERS.get(username)
         if user and user["password"] == password:
             st.session_state["user"] = {"username": username, **user}
         else:
-            st.sidebar.error("פרטי התחברות שגויים")
+            st.error("פרטי התחברות שגויים")
 
 
 if "user" not in st.session_state:
@@ -184,71 +199,79 @@ df = compute_overall_score(df_db, weights)
 df, trend_fields = compute_trends(df, list(weights.keys()))
 df = apply_flags(df, low_percentile_thr, drop_thr, trend_fields)
 
-st.markdown("### דשבורד כיתתי")
-view_df = df.copy()
-show_cols = [
-    c
-    for c in [
-        "student_name",
-        "class_name",
-        "semester",
-        "overall_score",
-        "quiz_avg",
-        "quarter_exam",
-        "midterm_mock",
-        "half_semester_final",
-        "national_percentile",
-        "flagged",
-    ]
-    if c in view_df.columns
-]
-st.dataframe(
-    view_df[show_cols].sort_values(
-        by=[c for c in ["flagged", "overall_score"] if c in show_cols],
-        ascending=[False, False],
-    )
-)
-
-filtered = view_df[view_df["flagged"]] if "flagged" in view_df.columns else view_df
-csv = filtered.to_csv(index=False).encode("utf-8-sig")
-st.download_button(
-    "⬇️ הורד CSV מסונן (קריטריונים)",
-    data=csv,
-    file_name="filtered_students.csv",
-    mime="text/csv",
-)
-
-st.markdown("---")
-st.markdown("### פרופיל תלמיד")
+student = None
+sdf = pd.DataFrame()
 if "student_name" in df.columns:
     if role == "תלמיד":
         student = user.get("student_name")
-        st.write(f"תלמיד/ה: {student}")
     else:
-        student = st.selectbox("בחר תלמיד/ה", sorted(df["student_name"].dropna().unique().tolist()))
+        student = st.selectbox(
+            "בחר תלמיד/ה", sorted(df["student_name"].dropna().unique().tolist())
+        )
     sdf = df[df["student_name"] == student].copy()
 
-    tab_grades, tab_comments, tab_graphs = st.tabs(["📊 ציונים", "📝 הערות", "📈 גרפים"])
+tab_scores, tab_comments, tab_graphs = st.tabs(["📊 ציונים", "📝 הערות", "📈 גרפים"])
 
-    with tab_grades:
-        st.subheader("📊 ציונים")
+with tab_scores:
+    st.markdown("### דשבורד כיתתי")
+    view_df = df.copy()
+    show_cols = [
+        c
+        for c in [
+            "student_name",
+            "class_name",
+            "semester",
+            "overall_score",
+            "quiz_avg",
+            "quarter_exam",
+            "midterm_mock",
+            "half_semester_final",
+            "national_percentile",
+            "flagged",
+        ]
+        if c in view_df.columns
+    ]
+    st.dataframe(
+        view_df[show_cols].sort_values(
+            by=[c for c in ["flagged", "overall_score"] if c in show_cols],
+            ascending=[False, False],
+        )
+    )
+    filtered = view_df[view_df["flagged"]] if "flagged" in view_df.columns else view_df
+    csv = filtered.to_csv(index=False).encode("utf-8-sig")
+    st.download_button(
+        "⬇️ הורד CSV מסונן (קריטריונים)",
+        data=csv,
+        file_name="filtered_students.csv",
+        mime="text/csv",
+    )
+    if not sdf.empty:
+        st.markdown("---")
+        st.subheader("פרופיל תלמיד")
         with st.expander("רשומות תלמיד (לפי סמסטר/אירוע)"):
             st.dataframe(sdf)
 
-    with tab_comments:
-        st.subheader("📝 הערות")
+with tab_comments:
+    st.subheader("הערות")
+    if sdf.empty:
+        st.info("אין נתונים עבור תלמיד/ה זה.")
+    else:
         comments_store = st.session_state["teacher_comments"]
         base_comments = []
         if "teacher_comment" in sdf.columns:
             base_comments = [str(x) for x in sdf["teacher_comment"].dropna().unique().tolist()]
         comments_store.setdefault(student, [])
         key_new = f"new_comment_{student}"
+        if key_new not in st.session_state:
+            st.session_state[key_new] = ""
         if role == "מורה":
             new_comment = st.text_area("הוסף הערה חדשה", key=key_new)
             if st.button("שמור הערה", key=f"save_comment_{student}"):
-                if new_comment.strip():
-                    comments_store[student].append(new_comment.strip())
-                    st.session_state[key_new] = ""
+                comment = st.session_state.get(key_new, "").strip()
+                if comment:
+                    comments_store[student].append(comment)
+                    st.session_state.pop(key_new)
+                    st.experimental_rerun()
         all_comments = base_comments + comments_store.get(student, [])
         if all_comments:
             for c in all_comments:
@@ -258,17 +281,18 @@ if "student_name" in df.columns:
         if "coordinator_comment" in sdf.columns:
             with st.expander("הערכת הרכז"):
                 st.write(" \n".join([str(x) for x in sdf["coordinator_comment"].dropna().unique().tolist()]))
-    with tab_graphs:
-        st.subheader("📈 גרפים")
-        if "semester" in sdf.columns:
-            for metric in ["quiz_avg", "quarter_exam", "midterm_mock", "half_semester_final"]:
-                if metric in sdf.columns:
-                    with st.expander(f"מדד: {CANON[metric]['label_he']}"):
-                        try:
-                            pivot_m = (
-                                sdf.pivot_table(index="semester", values=metric, aggfunc="mean").reset_index()
-                            )
-                            pivot_m = pivot_m.sort_values("semester")
-                            st.line_chart(pivot_m.set_index("semester"))
-                        except Exception as e:
-                            st.info(f"לא ניתן להציג גרף ל-{metric}: {e}")
+
+with tab_graphs:
+    st.subheader("גרפים")
+    if sdf.empty:
+        st.info("אין נתונים עבור תלמיד/ה זה.")
+    elif "semester" in sdf.columns:
+        for metric in ["quiz_avg", "quarter_exam", "midterm_mock", "half_semester_final"]:
+            if metric in sdf.columns:
+                with st.expander(f"מדד: {CANON[metric]['label_he']}"):
+                    try:
+                        pivot_m = sdf.pivot_table(index="semester", values=metric, aggfunc="mean").reset_index()
+                        pivot_m = pivot_m.sort_values("semester")
+                        st.line_chart(pivot_m.set_index("semester"))
+                    except Exception as e:
+                        st.info(f"לא ניתן להציג גרף ל-{metric}: {e}")

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,7 +1,12 @@
 import pandas as pd
 import pytest
 
-from src.analytics import normalize_weights, compute_trends, apply_flags
+from src.analytics import (
+    normalize_weights,
+    compute_trends,
+    apply_flags,
+    compute_overall_score,
+)
 
 
 def test_normalize_weights():
@@ -10,6 +15,13 @@ def test_normalize_weights():
     assert pytest.approx(1.0) == sum(normalized.values())
     assert normalized["quiz_avg"] == pytest.approx(0.25)
     assert normalized["quarter_exam"] == pytest.approx(0.75)
+
+
+def test_normalize_weights_invalid():
+    with pytest.raises(ValueError):
+        normalize_weights({})
+    with pytest.raises(ValueError):
+        normalize_weights({"a": -1})
 
 
 def test_apply_flags_percentile():
@@ -33,3 +45,28 @@ def test_compute_trends():
     assert "delta_quiz_avg" in out.columns
     delta_val = out.loc[out["student_name"] == "A", "delta_quiz_avg"].iloc[0]
     assert delta_val == 10
+
+
+def test_compute_trends_missing_column():
+    df = pd.DataFrame({"student_name": ["A"], "semester": ["א"]})
+    out, trend_fields = compute_trends(df, ["quiz_avg"])
+    assert trend_fields == []
+    assert "delta_quiz_avg" not in out.columns
+
+
+def test_compute_overall_score():
+    df = pd.DataFrame({"quiz_avg": [80], "quarter_exam": [90]})
+    weights = normalize_weights({"quiz_avg": 0.4, "quarter_exam": 0.6})
+    result = compute_overall_score(df.copy(), weights)
+    expected = 0.4 * 80 + 0.6 * 90
+    assert result["overall_score"].iloc[0] == pytest.approx(expected)
+
+
+def test_compute_overall_score_missing_and_empty():
+    df = pd.DataFrame({"quiz_avg": [80]})
+    weights = normalize_weights({"quiz_avg": 1.0, "quarter_exam": 1.0})
+    result = compute_overall_score(df.copy(), weights)
+    # missing "quarter_exam" column should simply ignore that weight
+    assert result["overall_score"].iloc[0] == pytest.approx(40.0)
+    empty = compute_overall_score(pd.DataFrame(), weights)
+    assert empty.empty

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,0 +1,27 @@
+import pandas as pd
+import pytest
+
+from src.data_loader import load_excel, map_columns, normalize_dataframe
+
+
+def test_load_excel_sample():
+    df = load_excel("data/sample_class.xlsx")
+    assert not df.empty
+
+
+def test_map_columns_and_normalize():
+    df_raw = pd.DataFrame({
+        "Name": ["A"],
+        "Quiz": ["90"],
+        "Extra": [1],
+    })
+    mappings = {"student_name": "Name", "quiz_avg": "Quiz", "quarter_exam": "(ללא)"}
+    mapped = map_columns(df_raw, mappings)
+    assert list(mapped.columns) == ["student_name", "quiz_avg"]
+    normalized = normalize_dataframe(df_raw, mappings)
+    assert normalized["quiz_avg"].iloc[0] == 90
+    assert "quarter_exam" not in normalized.columns
+    df_raw2 = pd.DataFrame({"Quiz": ["notnum"]})
+    mappings2 = {"quiz_avg": "Quiz"}
+    norm2 = normalize_dataframe(df_raw2, mappings2)
+    assert pd.isna(norm2["quiz_avg"].iloc[0])


### PR DESCRIPTION
## Summary
- add input validation for analytics weights and robust overall score calculation
- redesign login form and reorganize app into tabs with stable comment storage
- extend test suite for analytics functions and data loading

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c083b6848083298b777615ab7596e8