### PR TITLE
Revamp comments, login UI and add analytics tests

### DIFF
--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,7 +1,12 @@
 import pandas as pd
 import pytest
 
-from src.analytics import normalize_weights, compute_trends, apply_flags
+from src.analytics import (
+    normalize_weights,
+    compute_trends,
+    apply_flags,
+    compute_overall_score,
+)
 
 
 def test_normalize_weights():
@@ -10,6 +15,13 @@ def test_normalize_weights():
     assert pytest.approx(1.0) == sum(normalized.values())
     assert normalized["quiz_avg"] == pytest.approx(0.25)
     assert normalized["quarter_exam"] == pytest.approx(0.75)
+
+
+def test_normalize_weights_invalid():
+    with pytest.raises(ValueError):
+        normalize_weights({})
+    with pytest.raises(ValueError):
+        normalize_weights({"a": -1})
 
 
 def test_apply_flags_percentile():
@@ -33,3 +45,28 @@ def test_compute_trends():
     assert "delta_quiz_avg" in out.columns
     delta_val = out.loc[out["student_name"] == "A", "delta_quiz_avg"].iloc[0]
     assert delta_val == 10
+
+
+def test_compute_trends_missing_column():
+    df = pd.DataFrame({"student_name": ["A"], "semester": ["א"]})
+    out, trend_fields = compute_trends(df, ["quiz_avg"])
+    assert trend_fields == []
+    assert "delta_quiz_avg" not in out.columns
+
+
+def test_compute_overall_score():
+    df = pd.DataFrame({"quiz_avg": [80], "quarter_exam": [90]})
+    weights = normalize_weights({"quiz_avg": 0.4, "quarter_exam": 0.6})
+    result = compute_overall_score(df.copy(), weights)
+    expected = 0.4 * 80 + 0.6 * 90
+    assert result["overall_score"].iloc[0] == pytest.approx(expected)
+
+
+def test_compute_overall_score_missing_and_empty():
+    df = pd.DataFrame({"quiz_avg": [80]})
+    weights = normalize_weights({"quiz_avg": 1.0, "quarter_exam": 1.0})
+    result = compute_overall_score(df.copy(), weights)
+    # missing "quarter_exam" column should simply ignore that weight
+    assert result["overall_score"].iloc[0] == pytest.approx(40.0)
+    empty = compute_overall_score(pd.DataFrame(), weights)
+    assert empty.empty

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,0 +1,27 @@
+import pandas as pd
+import pytest
+
+from src.data_loader import load_excel, map_columns, normalize_dataframe
+
+
+def test_load_excel_sample():
+    df = load_excel("data/sample_class.xlsx")
+    assert not df.empty
+
+
+def test_map_columns_and_normalize():
+    df_raw = pd.DataFrame({
+        "Name": ["A"],
+        "Quiz": ["90"],
+        "Extra": [1],
+    })
+    mappings = {"student_name": "Name", "quiz_avg": "Quiz", "quarter_exam": "(ללא)"}
+    mapped = map_columns(df_raw, mappings)
+    assert list(mapped.columns) == ["student_name", "quiz_avg"]
+    normalized = normalize_dataframe(df_raw, mappings)
+    assert normalized["quiz_avg"].iloc[0] == 90
+    assert "quarter_exam" not in normalized.columns
+    df_raw2 = pd.DataFrame({"Quiz": ["notnum"]})
+    mappings2 = {"quiz_avg": "Quiz"}
+    norm2 = normalize_dataframe(df_raw2, mappings2)
+    assert pd.isna(norm2["quiz_avg"].iloc[0])


### PR DESCRIPTION
## Summary
- add input validation for analytics weights and robust overall score calculation
- redesign login form and reorganize app into tabs with stable comment storage
- extend test suite for analytics functions and data loading
- stabilize per-student comment saving using session state callbacks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c083b6848083298b777615ab7596e8